### PR TITLE
Improve loghandling in upgrade

### DIFF
--- a/scripts/dockers/nginx-init/nginx.conf
+++ b/scripts/dockers/nginx-init/nginx.conf
@@ -107,17 +107,12 @@ http {
            }
 
            location /updating {
-                expires 5m;
-                add_header Pragma public;
-                add_header Cache-Control "public, must-revalidate, proxy-revalidate";
                 index updater-view.html;
                 alias /opt/cfg/upgrade/;
             }
 
             location /logs {
-               expires 5m;
-               add_header Pragma public;
-                add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+                add_header X-Production "true";
                 index update_env.log;
                 alias /opt/logs/;
            }

--- a/scripts/dockers/nginx-init/upgrade.conf
+++ b/scripts/dockers/nginx-init/upgrade.conf
@@ -69,9 +69,6 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
 
             location ^~ /updating/ {
-                expires 5m;
-                add_header Pragma public;
-                add_header Cache-Control "public, must-revalidate, proxy-revalidate";
                 index updater-view.html;
                 alias /opt/cfg/upgrade/;
             }
@@ -85,9 +82,6 @@ http {
            }
 
            location ^~ /logs {
-               expires 5m;
-               add_header Pragma public;
-                add_header Cache-Control "public, must-revalidate, proxy-revalidate";
                 index update_env.log;
                 alias /opt/logs/;
            }

--- a/scripts/install/web-files/updater-view.html
+++ b/scripts/install/web-files/updater-view.html
@@ -16,6 +16,7 @@
             var doneMessage = '';
             var url = "/logs/?" + new Date().getTime();
             var ansi_up = new AnsiUp;
+            var elem = document.getElementById('logs');
             function send(){
                 $.ajax({
                 url: url,
@@ -25,14 +26,20 @@
                 success: function(data, status, resp) {
                     range = resp.getResponseHeader('content-range');
                     seeker = parseInt(range.split('/')[1]);
-                    if (data.search('Updating env done.') == -1 && data.search('Failed to update env.') == -1){
-                        data = ansi_up.ansi_to_html(data);
-                        $('#logs').append(data);
-                        bottom();
+                    var isdone = resp.getResponseHeader('X-Production');
+                    var scrolldown = false;
+                    data = ansi_up.ansi_to_html(data);
+                    if (elem.scrollTop == elem.scrollTopMax) {
+                        scrolldown = true;
+                    }
+                    $('#logs').append(data);
+                    if (scrolldown) {
+                        elem.scrollTop = elem.scrollTopMax;
+                    }
+                    if (isdone != 'true'){
                         setTimeout(send, 5000);
                     } else {
-                        doneMessage = data;
-                        finish();
+                        $("#redirect").toggleClass("hidden", false);
                     }
                 },
                 error: function(resp, status, error) {
@@ -46,28 +53,6 @@
                 });
             }
             send();
-            function bottom() {
-                var elem = document.getElementById('logs');
-                elem.scrollTop = elem.scrollHeight;
-            }
-            function finish(){
-                $.ajax({
-                url: "/testdone",
-                success: function(data, status, resp) {
-                    setTimeout(finish, 2000);
-                },
-                error: function(resp, status, error) {
-                    if (resp.status == 404 ) {
-                        $('#logs').append(doneMessage);
-                        bottom();
-                        $("#redirect").toggleClass("hidden", false);
-                        return;
-                    }
-                    setTimeout(finish, 2000);
-                }
-    
-                });
-            }
         });
 </script>
 </head>


### PR DESCRIPTION
We know production sends a special header for logs so when we have a
file + this header update is done

Only scroll down when scrollbar is at the bottom

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>